### PR TITLE
Make tests pass on https://github.com/rmcolq/pandora/pull/223

### DIFF
--- a/include/fastaq_handler.h
+++ b/include/fastaq_handler.h
@@ -24,7 +24,9 @@ struct FastaqHandler {
     std::string name;
     std::string read;
     uint32_t num_reads_parsed;
-    int read_status; // https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+    int read_status;   // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+    int closed_status; // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+
 
     FastaqHandler(const std::string&);
 
@@ -39,6 +41,9 @@ struct FastaqHandler {
     void get_id(const uint32_t&);
 
     void close();
+
+    bool is_closed() const;
+
 };
 
 #endif

--- a/include/fastaq_handler.h
+++ b/include/fastaq_handler.h
@@ -21,8 +21,8 @@ struct FastaqHandler {
     bool gzipped;
     gzFile fastaq_file;
     kseq_t* inbuf;
-    std::string name;
-    std::string read;
+    std::string name, next_name;
+    std::string read, next_read;
     uint32_t num_reads_parsed;
     int read_status;   // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
     int closed_status; // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
@@ -44,6 +44,8 @@ struct FastaqHandler {
 
     bool is_closed() const;
 
+private:
+    void read_ahead_next_read();
 };
 
 #endif

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -26,7 +26,11 @@ FastaqHandler::FastaqHandler(const std::string& filepath)
     this->inbuf = kseq_init(this->fastaq_file);
 }
 
-FastaqHandler::~FastaqHandler() { close(); }
+FastaqHandler::~FastaqHandler() {
+    if (!this->is_closed()) {
+        close();
+    }
+}
 
 bool FastaqHandler::eof() const { return (this->read_status == -1); }
 

--- a/test/estimate_parameters_test.cpp
+++ b/test/estimate_parameters_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(EstimateParameters_FitMeanCovg, Empty)
 {

--- a/test/fastaq_handler_test.cpp
+++ b/test/fastaq_handler_test.cpp
@@ -71,6 +71,24 @@ TEST(FastaqHandlerTest, get_next)
     EXPECT_EQ(fh.read, "another junk line");
 }
 
+TEST(FastaqHandlerTest, eof)
+{
+    FastaqHandler fh(TEST_CASE_DIR + "reads.fa");
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_TRUE(fh.eof());
+    fh.get_next();
+    EXPECT_TRUE(fh.eof());
+}
+
 TEST(FastaqHandlerTest, get_id_fa)
 {
     FastaqHandler fh(TEST_CASE_DIR + "reads.fa");

--- a/test/fastaq_handler_test.cpp
+++ b/test/fastaq_handler_test.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(FastaqHandlerTest, create_fa)
 {

--- a/test/index_test.cpp
+++ b/test/index_test.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(IndexTest, add_record)
 {

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(LocalPRGTest, create)
 {

--- a/test/pangraph_test.cpp
+++ b/test/pangraph_test.cpp
@@ -16,7 +16,7 @@
 
 using namespace pangenome;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(PangenomeGraphConstructor, constructors_and_get_sample)
 {

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(UtilsTest, split)
 {

--- a/test/vcf_test.cpp
+++ b/test/vcf_test.cpp
@@ -18,7 +18,7 @@ using ::testing::Property;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(VCFTest, add_record_with_values)
 {


### PR DESCRIPTION
Detailed comments about the changes are inlined (better than to put all here, I guess).

Main bug was that `FastaqHandler::get_next()` had to read the last sequence _twice_ before `FastaqHandler::eof()` would return true. This is because in the first read of the last sequence, `kseq` would return that the read was successful, but only _after_ the second read it would return that `EOF` was reached. Moreover, the `kseq` library is very limited. There is no functionality to check if `EOF` was reached before trying to read. The only functions `kseq` exposes to us is `kseq_init()`, `kseq_destroy()`, and `kseq_read()`, so we have to work around `kseq_read()`. The main changes on `FastaqHandler` class was to work around this with a read ahead implementation: a `FastaqHandler` object will always read the next sequence _before_ it is requested, so that when it is requested, it is already ready to use, and `EOF` can be detected correctly.

With this read ahead implementation, `FastaqHandler::eof()` returns true after the last sequence is read, and all tests are passing.