### PR TITLE
Klib simplified

### DIFF
--- a/include/fastaq_handler.h
+++ b/include/fastaq_handler.h
@@ -24,7 +24,9 @@ struct FastaqHandler {
     std::string name;
     std::string read;
     uint32_t num_reads_parsed;
-    int read_status; // https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+    int read_status;   // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+    int closed_status; // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
+
 
     FastaqHandler(const std::string&);
 
@@ -39,6 +41,9 @@ struct FastaqHandler {
     void get_id(const uint32_t&);
 
     void close();
+
+    bool is_closed() const;
+
 };
 
 #endif

--- a/include/fastaq_handler.h
+++ b/include/fastaq_handler.h
@@ -24,7 +24,6 @@ struct FastaqHandler {
     std::string name;
     std::string read;
     uint32_t num_reads_parsed;
-    int read_status;   // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
     int closed_status; // see https://github.com/attractivechaos/klib/blob/928581a78413bed4efa956731b35b18a638f20f3/kseq.h#L171
 
 

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -32,7 +32,7 @@ FastaqHandler::~FastaqHandler() {
     }
 }
 
-bool FastaqHandler::eof() const { return (this->read_status == -1); }
+bool FastaqHandler::eof() const { return ks_eof(this->inbuf->f); }
 
 void FastaqHandler::get_next()
 {

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -13,7 +13,6 @@ FastaqHandler::FastaqHandler(const std::string& filepath)
     , filepath(filepath)
     , gzipped(false)
     , num_reads_parsed(0)
-    , read_status(0)
 {
     // level for boost logging
     //    logging::core::get()->set_filter(logging::trivial::severity >= g_log_level);
@@ -36,15 +35,16 @@ bool FastaqHandler::eof() const { return ks_eof(this->inbuf->f); }
 
 void FastaqHandler::get_next()
 {
-    this->read_status = kseq_read(this->inbuf);
+    int read_status = kseq_read(this->inbuf);
 
-    if (this->eof()) {
+    bool no_more_reads_available = read_status == -1;
+    if (no_more_reads_available) {
         return;
     }
 
-    if (this->read_status == -2) {
+    if (read_status == -2) {
         throw "Truncated quality string detected";
-    } else if (this->read_status == -3) {
+    } else if (read_status == -3) {
         throw "Error reading " + this->filepath;
     }
 

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -26,7 +26,11 @@ FastaqHandler::FastaqHandler(const std::string& filepath)
     this->inbuf = kseq_init(this->fastaq_file);
 }
 
-FastaqHandler::~FastaqHandler() { close(); }
+FastaqHandler::~FastaqHandler() {
+    if (!this->is_closed()) {
+        close();
+    }
+}
 
 bool FastaqHandler::eof() const { return (this->read_status == -1); }
 

--- a/test/estimate_parameters_test.cpp
+++ b/test/estimate_parameters_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(EstimateParameters_FitMeanCovg, Empty)
 {

--- a/test/fastaq_handler_test.cpp
+++ b/test/fastaq_handler_test.cpp
@@ -71,6 +71,24 @@ TEST(FastaqHandlerTest, get_next)
     EXPECT_EQ(fh.read, "another junk line");
 }
 
+TEST(FastaqHandlerTest, eof)
+{
+    FastaqHandler fh(TEST_CASE_DIR + "reads.fa");
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_FALSE(fh.eof());
+    fh.get_next();
+    EXPECT_TRUE(fh.eof());
+    fh.get_next();
+    EXPECT_TRUE(fh.eof());
+}
+
 TEST(FastaqHandlerTest, get_id_fa)
 {
     FastaqHandler fh(TEST_CASE_DIR + "reads.fa");

--- a/test/fastaq_handler_test.cpp
+++ b/test/fastaq_handler_test.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(FastaqHandlerTest, create_fa)
 {

--- a/test/index_test.cpp
+++ b/test/index_test.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(IndexTest, add_record)
 {

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(LocalPRGTest, create)
 {

--- a/test/pangraph_test.cpp
+++ b/test/pangraph_test.cpp
@@ -16,7 +16,7 @@
 
 using namespace pangenome;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(PangenomeGraphConstructor, constructors_and_get_sample)
 {

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(UtilsTest, split)
 {

--- a/test/vcf_test.cpp
+++ b/test/vcf_test.cpp
@@ -18,7 +18,7 @@ using ::testing::Property;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
-const std::string TEST_CASE_DIR = "test_cases/";
+const std::string TEST_CASE_DIR = "../../test/test_cases/";
 
 TEST(VCFTest, add_record_with_values)
 {


### PR DESCRIPTION
An alternative, smaller and more simplified solution to https://github.com/mbhall88/pandora/pull/1 . I highly recommend this implementation because it has way less code than https://github.com/mbhall88/pandora/pull/1, and does the same thing. Less code is always better.

Comparison with https://github.com/mbhall88/pandora/pull/1:
- The 3 first commits are also in https://github.com/mbhall88/pandora/pull/1 (I just cherry-picked them);
- There is no read ahead implementation, we just have a more careful implementation of `FastaqHandler::eof()` and `FastaqHandler::get_next()` WRT `kseq.h`;

Main changes:
- `FastaqHandler::eof()` is correctly implemented a la `kseq.h` (there is no more need for `FastaqHandler::read_status`, which is also nice);
- Due to the previous fix, we had to change the way `FastaqHandler::get_next()` recognises that there is no more reads to be read;